### PR TITLE
lib/services: give the portable layer process.environment

### DIFF
--- a/compliance/README.md
+++ b/compliance/README.md
@@ -3,7 +3,8 @@
 Compliance suite for [modular service](../doc/modular-services.md) integrations.
 
 Tests that a service manager integration correctly handles the portable modular
-services contract: `process.argv`, sub-services, assertions, and warnings.
+services contract: `process.argv`, `process.environment` (including `null`
+values that unset a variable), sub-services, assertions, and warnings.
 
 The suite is integration-agnostic. Each integration under
 [`integrations/`](../integrations) instantiates it once, supplying the four

--- a/compliance/default.nix
+++ b/compliance/default.nix
@@ -28,6 +28,10 @@ let
     services = {
       svc = {
         process.argv = [ "${coreutils}/bin/true" ];
+        process.environment = {
+          FOO = "bar";
+          DROPPED = null;
+        };
         assertions = [
           {
             assertion = true;
@@ -67,6 +71,19 @@ let
       testSubServiceArgv = {
         expr = c.services.child.process.argv;
         expected = [ "${coreutils}/bin/true" ];
+      };
+
+      # A set environment variable round-trips through process.environment.
+      testProcessEnvironment = {
+        expr = c.process.environment.FOO;
+        expected = "bar";
+      };
+
+      # A null environment variable is preserved as null (unset request),
+      # rather than coerced to a string or dropped from the attrset.
+      testProcessEnvironmentNull = {
+        expr = c.process.environment.DROPPED;
+        expected = null;
       };
 
       testAssertions = {
@@ -185,6 +202,9 @@ let
     mkdir -p "$dir"
     echo "$$" > "$dir/pid"
     printf '%s\n' "$@" > "$dir/args"
+    # Record the process's own environment as received from the service
+    # manager (NUL-delimited, as the kernel stores it).
+    "${coreutils}/bin/cat" "/proc/$$/environ" > "$dir/environ"
     exec "${coreutils}/bin/sleep" infinity
   '';
 
@@ -236,6 +256,31 @@ let
       grep -qxF -- ${lib.escapeShellArg arg} "${sharedDir}/${id}/args" \
         || { echo "${id}: expected arg ${lib.escapeShellArg arg} not found"; cat "${sharedDir}/${id}/args"; exit 1; }
     '') expectedArgs;
+
+  /**
+    Shell snippet: assert that the service's recorded environment contains
+    each `present` entry (an exact `KEY=value` string) and contains no
+    variable named in `absent`.
+  */
+  checkEnv =
+    id:
+    {
+      present ? [ ],
+      absent ? [ ],
+    }:
+    ''
+      # The recorded environ is NUL-delimited; render one entry per line.
+      tr '\0' '\n' < "${sharedDir}/${id}/environ" > "${sharedDir}/${id}/environ.lines"
+    ''
+    + lib.concatMapStrings (entry: ''
+      grep -qxF -- ${lib.escapeShellArg entry} "${sharedDir}/${id}/environ.lines" \
+        || { echo "${id}: expected env ${lib.escapeShellArg entry} not found"; cat "${sharedDir}/${id}/environ.lines"; exit 1; }
+    '') present
+    + lib.concatMapStrings (key: ''
+      if grep -qE ${lib.escapeShellArg "^${key}="} "${sharedDir}/${id}/environ.lines"; then
+        echo "${id}: env variable ${lib.escapeShellArg key} should be unset"; exit 1
+      fi
+    '') absent;
 
   mkTestScript =
     name: text:
@@ -326,6 +371,24 @@ in
         "--greeting"
         "hello"
       ]
+    );
+  };
+
+  environment = mkTest {
+    name = "${namePrefix}-environment";
+    services.test = {
+      process.argv = mkArgv "env" [ ];
+      process.environment = {
+        FOO = "bar";
+        DROPPED = null;
+      };
+    };
+    testExe = mkTestScript "environment" (
+      waitAndCheck "env" [ ]
+      + checkEnv "env" {
+        present = [ "FOO=bar" ];
+        absent = [ "DROPPED" ];
+      }
     );
   };
 

--- a/integrations/nixos/systemd/service.nix
+++ b/integrations/nixos/systemd/service.nix
@@ -209,7 +209,15 @@ in
     systemd.services."" = {
       # TODO description;
       wantedBy = lib.mkDefault [ "multi-user.target" ];
+      environment = lib.mapAttrs (_: lib.mkDefault) (
+        lib.filterAttrs (_: v: v != null) config.process.environment
+      );
       serviceConfig = {
+        UnsetEnvironment =
+          let
+            nullEnvKeys = lib.attrNames (lib.filterAttrs (_: v: v == null) config.process.environment);
+          in
+          lib.mkIf (nullEnvKeys != [ ]) (lib.concatStringsSep " " nullEnvKeys);
         ExecReload = lib.mkIf (config.systemd.mainExecReload != null) config.systemd.mainExecReload;
         Type = lib.mkDefault (if config.notificationProtocol.systemd then "notify" else "simple");
         Restart = lib.mkDefault "always";

--- a/integrations/nixos/tests/units.nix
+++ b/integrations/nixos/tests/units.nix
@@ -76,6 +76,41 @@ let
         };
       };
 
+      # Test that `process.environment` becomes `Environment=` entries on the unit,
+      # that null values are dropped from `Environment=` and listed in
+      # `UnsetEnvironment=`.
+      system.services.envvars = {
+        process = {
+          argv = [ hello' ];
+          environment = {
+            FOO = "bar";
+            BAZ = "qux";
+            DROPPED = null;
+          };
+        };
+      };
+
+      # Test that an explicit `systemd.service.environment` override wins over
+      # the portable default produced by `process.environment`.
+      system.services.envvars-override = {
+        process = {
+          argv = [ hello' ];
+          environment.FOO = "from-process";
+        };
+        systemd.service.environment.FOO = "from-systemd";
+      };
+
+      # Test that `process.environment` `null` unsets via `UnsetEnvironment=` even
+      # when the systemd layer sets the same key (true unset, not just "skip
+      # setting").
+      system.services.envvars-unset = {
+        process = {
+          argv = [ hello' ];
+          environment.FOO = null;
+        };
+        systemd.service.environment.FOO = "leaked";
+      };
+
       # Test extending process.argv with systemd specifiers
       system.services.argv-extended =
         { config, ... }:
@@ -136,6 +171,24 @@ runCommand "test-modular-service-systemd-units"
       # Test extending process.argv with systemd specifiers
       # The base command should be escaped ($1 -> $$1, m%n -> m%%n), but the appended --systemd-unit %n should not be
       grep -F 'ExecStart="${hello}/bin/hello" "--greeting" "Fun $$1 fact, remainder is often expressed as m%%n" --systemd-unit %n' ${toplevel}/etc/systemd/system/argv-extended.service >/dev/null
+
+      # process.environment becomes Environment= entries; null values are dropped
+      # from Environment= and listed in UnsetEnvironment=.
+      grep -F 'Environment="FOO=bar"' ${toplevel}/etc/systemd/system/envvars.service >/dev/null
+      grep -F 'Environment="BAZ=qux"' ${toplevel}/etc/systemd/system/envvars.service >/dev/null
+      ! grep -F 'Environment=.*DROPPED' ${toplevel}/etc/systemd/system/envvars.service
+      grep -F 'UnsetEnvironment=DROPPED' ${toplevel}/etc/systemd/system/envvars.service >/dev/null
+
+      # systemd.service.environment override wins over process.environment.
+      grep -F 'Environment="FOO=from-systemd"' ${toplevel}/etc/systemd/system/envvars-override.service >/dev/null
+      ! grep -F 'FOO=from-process' ${toplevel}/etc/systemd/system/envvars-override.service
+
+      # process.environment null uses UnsetEnvironment= for true unset, even when
+      # the systemd layer has an Environment= entry for the same key. The
+      # Environment= entry is still emitted; UnsetEnvironment= removes it as the
+      # final step at runtime.
+      grep -F 'Environment="FOO=leaked"' ${toplevel}/etc/systemd/system/envvars-unset.service >/dev/null
+      grep -F 'UnsetEnvironment=FOO' ${toplevel}/etc/systemd/system/envvars-unset.service >/dev/null
 
       [[ ! -e ${toplevel}/etc/systemd/system/foo.socket ]]
       [[ ! -e ${toplevel}/etc/systemd/system/bar.socket ]]

--- a/lib/services/service.nix
+++ b/lib/services/service.nix
@@ -188,6 +188,26 @@ in
           Command used for reloading in the underlying service manager to reload.
         '';
       };
+
+      environment = lib.mkOption {
+        type = types.lazyAttrsOf (
+          types.nullOr (types.coercedTo (types.either types.path types.package) (x: "${x}") types.str)
+        );
+        default = { };
+        example = lib.literalExpression ''{ FOO = "bar"; PATH = null; }'';
+        description = ''
+          Environment variables passed verbatim to the service process by the
+          service manager. Entries set to `null` actively unset the variable
+          before the process starts, using the backend's native unset mechanism
+          (for the systemd backend, `UnsetEnvironment=`), so the variable is
+          absent even when the service manager or a backend-specific override
+          would otherwise supply it.
+
+          Values appear in the rendered unit and may be world-readable. For
+          secrets, use a backend-specific mechanism such as
+          `systemd.service.serviceConfig.EnvironmentFile`.
+        '';
+      };
     };
 
     notificationProtocol = mkOption {

--- a/lib/services/test.nix
+++ b/lib/services/test.nix
@@ -57,6 +57,10 @@ let
             "world"
           ];
           reloadCommand = "${dummyPkg "cowsay.sh"} reload";
+          environment = {
+            FOO = "bar";
+            DROPPED = null;
+          };
         };
       };
       service3 = {
@@ -166,7 +170,14 @@ let
       inherit (config) warnings;
       assertions = failures config.assertions;
       # `flagFormat` is a function and cannot be compared; the rest of `process` is checked.
-      process = { inherit (config.process) argv reloadCommand reloadSignal; };
+      process = {
+        inherit (config.process)
+          argv
+          environment
+          reloadCommand
+          reloadSignal
+          ;
+      };
     }
     // {
       services = lib.mapAttrs (k: filterEval) config.services;
@@ -184,6 +195,7 @@ let
               ];
               reloadCommand = null;
               reloadSignal = null;
+              environment = { };
             };
             services = { };
             assertions = [
@@ -204,6 +216,10 @@ let
               ];
               reloadCommand = "${dummyPkg "cowsay.sh"} reload";
               reloadSignal = null;
+              environment = {
+                FOO = "bar";
+                DROPPED = null;
+              };
             };
             services = { };
             assertions = [ ];
@@ -214,6 +230,7 @@ let
               argv = [ "/bin/false" ];
               reloadCommand = null;
               reloadSignal = null;
+              environment = { };
             };
             services.exclacow = {
               process = {
@@ -223,6 +240,7 @@ let
                 ];
                 reloadCommand = "${dummyPkg "coreutils"}/bin/kill -HUP $MAINPID";
                 reloadSignal = "HUP";
+                environment = { };
               };
               services = { };
               assertions = [
@@ -250,6 +268,7 @@ let
               ];
               reloadCommand = null;
               reloadSignal = null;
+              environment = { };
             };
             services = { };
             assertions = [ ];
@@ -265,6 +284,7 @@ let
               ];
               reloadCommand = null;
               reloadSignal = null;
+              environment = { };
             };
             services = { };
             assertions = [ ];
@@ -281,6 +301,7 @@ let
               ];
               reloadCommand = null;
               reloadSignal = null;
+              environment = { };
             };
             services = { };
             assertions = [ ];
@@ -298,6 +319,7 @@ let
               ];
               reloadCommand = null;
               reloadSignal = null;
+              environment = { };
             };
             services = { };
             assertions = [ ];


### PR DESCRIPTION
Port of nixpkgs pull request 545521, "nixos/modular-services: add portable `process.environment` using `UnsetEnvironment`".

`process.environment` gives the portable layer a way to set environment variables without reaching for `systemd.service.environment`. A `null` value means *unset*: the systemd integration renders those keys into `UnsetEnvironment=` and the rest into `Environment=` at `mkDefault`, so an integration-level override still wins. The compliance suite gains a runtime `environment` test that reads the service's own `/proc/$$/environ`.

`lib/services/test.nix` differs from upstream's hunks because upstream branched before `filterEval` was narrowed and before `failures` existed here; only `environment` joins the compared `process` attributes.

Assisted-by: Claude:claude-fable-5-1
