### PR TITLE
lib/services: let `configure` take its base modules as an input

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -65,13 +65,13 @@ in the pinned nixpkgs.
 
 | repo path | nixpkgs path | state | reason |
 |---|---|---|---|
-| `lib/services/default.nix` | `lib/services/lib.nix` | modified | Renamed to `default.nix` so `import ./lib/services` resolves. The `configure` docstring is retargeted from a `nix-darwin` sketch to the `integrations/<name>/` contract, which makes it the how-to-add-an-integration guide. |
-| `lib/services/service.nix` | `lib/services/service.nix` | modified | The two out-of-tree imports point at `./vendor/` instead of `../../modules/generic/` and `../../nixos/modules/misc/`. |
+| `lib/services/default.nix` | `lib/services/lib.nix` | modified | Renamed to `default.nix` so `import ./lib/services` resolves. The `configure` docstring is retargeted from a `nix-darwin` sketch to the `integrations/<name>/` contract, which makes it the how-to-add-an-integration guide. Names `importService` from the portable layer itself, where upstream adds `lib.importService` to the nixpkgs `lib`. |
+| `lib/services/service.nix` | `lib/services/service.nix` | modified | The two out-of-tree imports point at `./vendor/` instead of `../modules/generic/`. |
 | `lib/services/config-data.nix` | `lib/services/config-data.nix` | modified | Test-path comment retargeted to `integrations/nixos/tests/etc/test.nix`. |
 | `lib/services/config-data-item.nix` | `lib/services/config-data-item.nix` | modified | Test-path comment retargeted to `integrations/nixos/tests/etc/test.nix`. |
 | `lib/services/test.nix` | `lib/services/test.nix` | modified | Takes `lib` as a parameter instead of `import ../.`, so it runs against whichever `lib` the consumer pins. Imports `./.` rather than `./lib.nix`. |
 | `lib/services/vendor/meta-maintainers.nix` | `modules/generic/meta-maintainers.nix` | verbatim | `lib`-only dependency of the portable layer; vendored so `lib/services` needs nothing outside itself. |
-| `lib/services/vendor/assertions.nix` | `nixos/modules/misc/assertions.nix` | verbatim | `lib`-only dependency of the portable layer; vendored so `lib/services` needs nothing outside itself. |
+| `lib/services/vendor/assertions.nix` | `lib/modules/generic/assertions.nix` | verbatim | `lib`-only dependency of the portable layer; vendored so `lib/services` needs nothing outside itself. Upstream keeps this next to `meta-maintainers.nix` under `lib/modules/generic/`, where it is class-agnostic (`_class = null`) rather than a NixOS module; the pinned nixpkgs still has the NixOS-only copy at `nixos/modules/misc/assertions.nix`. |
 | `compliance/default.nix` | `pkgs/build-support/testers/modular-service-compliance.nix` | modified | Two doc-link comments retargeted from the nixpkgs manual to `compliance/README.md`. |
 | `integrations/nixos/systemd/system.nix` | `nixos/modules/system/service/systemd/system.nix` | modified | The portable-layer import becomes `../../../lib/services`. This is the single line that made the whole in-tree `lib/services` reachable from a NixOS evaluation. |
 | `integrations/nixos/systemd/service.nix` | `nixos/modules/system/service/systemd/service.nix` | verbatim | |

--- a/lib/services/default.nix
+++ b/lib/services/default.nix
@@ -37,6 +37,16 @@ rec {
   );
 
   /**
+    The portable service base, `service.nix`, with its non-module dependency
+    applied: `importService { inherit pkgs; }` is a module. `configure` loads it
+    by default; pass it, or a copy pinned from another revision, as
+    `baseModules` to choose the base explicitly.
+
+    lib.services.importService :: { pkgs :: AttrSet } -> Module
+  */
+  importService = lib.modules.importApply ./service.nix;
+
+  /**
     Entrypoint for integrating modular services into a containing module system.
 
     Each containing system (NixOS, ...) calls `configure` to
@@ -63,6 +73,8 @@ rec {
 
       modularServiceConfiguration = portable-lib.configure {
         serviceManagerPkgs = pkgs;
+        # To load a different portable service base, set `baseModules` instead:
+        #   baseModules = [ (portable-lib.importService { inherit pkgs; }) ];
         extraRootModules = [
           ./launchd/service.nix    # launchd-specific options (plist generation, etc.)
         ];
@@ -103,18 +115,27 @@ rec {
     `serviceManagerPkgs`
 
     : 1\. A Nixpkgs instance used for built-in logic such as converting
-    `configData.<path>.text` to a store path.
+    `configData.<path>.text` to a store path. Required unless `baseModules`
+    is set.
+
+    `baseModules`
+
+    : 2\. Modules that replace the portable service base. They are loaded
+    into the "root" service submodule and must handle propagation to
+    sub-`services` themselves. Defaults to this repository's portable service
+    base, `importService { pkgs = serviceManagerPkgs; }`. Set it to supply a
+    different one, for example a `service.nix` pinned from another revision.
 
     `extraRootModules`
 
-    : 2\. Modules to be loaded into the "root" service submodule, but not
+    : 3\. Modules to be loaded into the "root" service submodule, but not
     into its sub-`services`. That's the modules' own responsibility.
     Typically contains service-manager-specific option modules
     (e.g. systemd unit options, launchd plist options).
 
     `extraRootSpecialArgs`
 
-    : 3\. Fixed module arguments provided alongside `extraRootModules`.
+    : 4\. Fixed module arguments provided alongside `extraRootModules`.
 
     # Output
 
@@ -124,17 +145,15 @@ rec {
   */
   configure =
     {
-      serviceManagerPkgs,
+      serviceManagerPkgs ? throw "lib.services.configure: `serviceManagerPkgs` is required unless `baseModules` is set",
+      baseModules ? [ (importService { pkgs = serviceManagerPkgs; }) ],
       extraRootModules ? [ ],
       extraRootSpecialArgs ? { },
     }:
     let
-      modules = [
-        (lib.modules.importApply ./service.nix { pkgs = serviceManagerPkgs; })
-      ];
       serviceSubmodule = types.submoduleWith {
         class = "service";
-        modules = modules ++ extraRootModules;
+        modules = baseModules ++ extraRootModules;
         specialArgs = extraRootSpecialArgs;
       };
     in

--- a/lib/services/vendor/assertions.nix
+++ b/lib/services/vendor/assertions.nix
@@ -1,5 +1,6 @@
 { lib, ... }:
 {
+  _class = null; # not specific to NixOS
 
   options = {
 


### PR DESCRIPTION
Port of nixpkgs pull request 507052, "lib/services: expose portable service lib as `lib.services`".

`configure` applied `./service.nix` to `serviceManagerPkgs` itself, which fixed both which base module an integration gets and where it is imported from. `baseModules` is now an input that defaults to `importService { pkgs = serviceManagerPkgs; }`; a caller that sets it no longer needs `serviceManagerPkgs`. `importService` is `service.nix` under `importApply`, exposed from the portable layer itself where upstream adds `lib.importService` to the nixpkgs `lib`. The vendored `assertions.nix` gains `_class = null`, from the copy upstream moves to `lib/modules/generic/`.

Upstream's `lib.services`, `lib.genericModules` and the `portable-lib = lib.services` call sites reach the portable layer through the consumer's nixpkgs `lib`, which this repository cannot add to. `default.nix` already exposes the layer as `lib.services` and `lib.servicesFor`, and the NixOS integration keeps importing `lib/services` by path.

Assisted-by: Claude:claude-fable-5-1
