### PR TITLE
doc: refresh the chapter's introduction and motivate the design

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -103,7 +103,7 @@ in the pinned nixpkgs.
 | `modular-services/ktls-utils/service.nix` | `pkgs/by-name/kt/ktls-utils/service.nix` | modified | The systemd definitions move to `integrations/nixos/modular/ktls-utils/default/system.nix`. |
 | `modular-services/snid/service.nix` | `pkgs/by-name/sn/snid/service.nix` | modified | The systemd definitions move to `integrations/nixos/modular/snid/default/system.nix`. |
 | `modular-services/php/service.nix` | `pkgs/development/interpreters/php/service.nix` | modified | Test-path comment retargeted to `integrations/nixos/tests/packages/php-fpm.nix`. The systemd definitions move to `integrations/nixos/modular/php/default/system.nix`, which takes `coreutils` with them, so the service's non-module dependencies narrow to `{ formats }`. |
-| `doc/modular-services.md` | `nixos/doc/manual/development/modular-services.md` | modified | Adds a note on this repository's relationship to nixpkgs; the consumption example uses `modularServices`. The two option-type links become absolute NixOS-manual URLs, because the chapter renders as a standalone book where a bare `#anchor` is resolved against the book and rejected when it names nothing. Links into this repository are absolute for the same reason, so that they resolve both here and in the rendered manual. Keeps the `@PORTABLE_SERVICE_OPTIONS@` / `@SYSTEMD_SERVICE_OPTIONS@` placeholders. |
+| `doc/modular-services.md` | `doc/modules/modular-services.section.md`, `nixos/doc/manual/development/modular-services.md` | modified | One chapter where nixpkgs has two: the portable material lives in the nixpkgs manual and the NixOS manual carries a pointer chapter with the systemd-specific options, whereas this is one book about the subsystem rather than one chapter per integration. Adds a note on this repository's relationship to nixpkgs; the consumption example uses `modularServices`. The two option-type links become absolute NixOS-manual URLs, because the chapter renders as a standalone book where a bare `#anchor` is resolved against the book and rejected when it names nothing. Links into this repository are absolute for the same reason, so that they resolve both here and in the rendered manual. Keeps the `@PORTABLE_SERVICE_OPTIONS@` / `@SYSTEMD_SERVICE_OPTIONS@` placeholders. |
 | `doc/writing-and-reviewing.md` | `nixos/README-modular-services.md` | modified | Review checklist and worked examples retargeted at this repository's paths, and links into it made absolute. Every heading gains an explicit anchor, because the file is a chapter of the rendered manual rather than a standalone README. |
 | `compliance/README.md` | `doc/build-helpers/testers.chapter.md` | modified | Extracted from the `modularServiceCompliance` section of the testers chapter; the nixpkgs-manual markup is dropped and the invocation example uses `self.lib.mkComplianceSuite`. |
 
@@ -112,7 +112,8 @@ in the pinned nixpkgs.
 - `nixos/tests/all-tests.nix`'s `callTest` / `findTests` plumbing. It exists to
   satisfy the nixpkgs test registry and has no counterpart here;
   `pkgs.testers.runNixOSTest` returns a derivation directly.
-- `nixos/modules/misc/documentation/modular-services.nix`. Replaced by
+- `nixos/modules/misc/documentation/modular-services.nix`, including its
+  `bundledModularServiceNames` list. Replaced by
   [`integrations/nixos/documentation.nix`](./integrations/nixos/documentation.nix),
   which is keyed on `modularServices` rather than on package `passthru`, and
   which covers `easytier` and `holo-daemon` -- two service modules the nixpkgs
@@ -132,6 +133,10 @@ in the pinned nixpkgs.
   directly.
 - `ci/OWNERS`, and `modules/generic/meta-maintainers/test.nix`. Both are nixpkgs
   CI plumbing; neither the ownership file nor that test is vendored here.
+- The nixpkgs manual's build plumbing for the modular-services chapter:
+  `doc/doc-support/package.nix`, `doc/redirects.json` and the
+  `package-module-options` entry in `pkgs/top-level/all-packages.nix`. This book
+  is built by [`doc/default.nix`](./doc/default.nix) instead.
 - `nixos/modules/system/service/README.md`. Superseded by
   [`integrations/nixos/README.md`](./integrations/nixos/README.md).
 - `pkgs/by-name/gi/git-pages/package.nix`. Its `passthru.services.default`

--- a/doc/modular-services.md
+++ b/doc/modular-services.md
@@ -1,18 +1,22 @@
 
 # Modular Services {#modular-services}
 
-Status: in development. This functionality is new in NixOS 25.11, and significant changes should be expected. We'd love to hear your feedback in <https://github.com/NixOS/nixpkgs/pull/372170>
+Status: in development. This functionality is new in release 25.11, and significant changes should be expected.
+We'd love to hear your feedback in our [matrix channel](https://matrix.to/#/#modular-services:nixos.org)
+or at the [tracking issue](https://github.com/NixOS/nixpkgs/issues/428084).
 
 This repository carries the subsystem outside of nixpkgs so that it can move at its own pace and be consumed by NixOS, Home Manager and `nix-darwin` alike.
 The in-tree nixpkgs copy is disabled at evaluation time; see [`integrations/nixos/disable-upstream.nix`](https://github.com/kiaragrouwstra/modular-services/blob/main/integrations/nixos/disable-upstream.nix).
 
-Traditionally, NixOS services were defined using sets of options *in* modules, not *as* modules. This made them non-modular, resulting in problems with composability, reuse, and portability.
+In NixOS, services were traditionally defined using sets of options *in* modules, not *as* modules. This made them non-modular, resulting in problems with composability, reuse, and portability.
 
 A configuration management framework is an application of `evalModules` with the `class` and `specialArgs` input attribute set to particular values.
-NixOS is such a configuration management framework, and so are [Home Manager](https://github.com/nix-community/home-manager) and [`nix-darwin`](https://github.com/nix-darwin/nix-darwin).
+NixOS is such a configuration management framework, and so are [Home Manager](https://github.com/nix-community/home-manager),
+[`nix-darwin`](https://github.com/nix-darwin/nix-darwin), [`nimi`](https://github.com/weyl-ai/nimi)
+and [`finix`](https://github.com/finix-community/finix).
 
 The service management component of a configuration management framework is the set of module options that connects Nix expressions with the underlying service (or process) manager.
-For NixOS this is the module wrapping [`systemd`](https://systemd.io/), on `nix-darwin` this is the module wrapping [`launchd`](https://en.wikipedia.org/wiki/Launchd).
+For NixOS this is the module wrapping [`systemd`](https://systemd.io/), on `nix-darwin` the module wrapping [`launchd`](https://en.wikipedia.org/wiki/Launchd), and on `finix` the module wrapping [`finit`](https://github.com/finit-project/finit).
 
 A *modular service* is a [module] that defines values for a core set of options declared in the service management component of a configuration management framework, including which program to run.
 Since it's a module, it can be composed with other modules via `imports` to extend its functionality.
@@ -48,9 +52,65 @@ So note that the default value of `system.services.<name>` is not a complete ser
 `modularServices.<pkg> pkgs` is that service on its own, for an integration whose service manager is not systemd.
 `pkgs.<pkg>.services.*` still resolves to the nixpkgs copy unless `overlays.passthruServices` is applied; see [the README](https://github.com/kiaragrouwstra/modular-services/blob/main/README.md#known-residue).
 
+## Motivation {#modular-service-motivation}
+
+Traditionally a NixOS service is a set of options *in* a module: one module declares `services.foo.*`, there is exactly one instance of it, and its name is fixed by whoever wrote the module.
+Such a service cannot be instantiated twice, cannot be extended without patching the module that declares it, and cannot be used outside NixOS.
+
+A modular service is a module *as* a service, which makes it:
+
+- **instantiable** more than once, under a name you choose, by importing it at `system.services.<name>`;
+- **extensible**, by importing further modules alongside it rather than editing it;
+- **composable**, since a service can contain sub-services of its own -- see [](#modular-service-composition);
+- **portable** across configuration management frameworks that declare the same core options -- see [](#modular-service-portability).
+
+This is also the answer to "why not just ship a systemd unit file".
+A unit file describes one service, for one service manager, in a format with no notion of options, types, defaults, or merging; it cannot be parameterized, imported twice under different names, or extended without editing it.
+A modular service is a module that *produces* such a unit, and going through the module system is what buys the four properties above.
+systemd-specific escapes remain available through the `systemd` option tree, guarded as shown in [](#modular-service-portability).
+
+The portable option set is still small, as we try to find reusable abstractions.
+It describes how to start the service (`process.argv`), optionally how to reload it (`process.reloadSignal`, `process.reloadCommand`, and `configData` for files whose contents may change without a restart), and how the service signals readiness (`notificationProtocol`).
+Everything else -- ordering, dependencies, restart policy, isolation -- is left to the service manager, and on NixOS is reached through the `systemd` options.
+
 ## Portability {#modular-service-portability}
 
-It is possible to write service modules that are portable. This is done by either avoiding the `systemd` option tree, or by defining process-manager-specific definitions in an optional way:
+It is possible to write service modules that are portable.
+This is done by either avoiding the `systemd` option tree, or by defining process-manager-specific definitions in an optional way.
+
+A module that only defines portable options is portable, but requires some translation layer to be picked up by a service manager:
+
+```nix
+# Non-module dependencies (`importApply`)
+{ pkgs }:
+
+# Service module
+{ config, lib, ... }:
+let
+  cfg = config.foo;
+  format = pkgs.formats.toml { };
+in
+{
+  _class = "service";
+
+  options.foo = {
+    package = lib.mkPackageOption pkgs "foo" { };
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      description = "Configuration for `foo`, rendered to `foo.toml`.";
+    };
+  };
+
+  config.process.argv = [
+    (lib.getExe cfg.package)
+    "--config"
+    (format.generate "foo.toml" cfg.settings)
+  ];
+}
+```
+
+You can define process-manager-specific definitions in an optional way like:
 
 ```nix
 {
@@ -95,8 +155,6 @@ Moving their logic into separate Nix files may still be beneficial for the effic
 <!-- TODO example of a single-instance service -->
 
 ## Writing and Reviewing a Modular Service {#modular-service-review}
-
-A typical service module consists of the following:
 
 For more details, refer to the contributor documentation in [Writing and Reviewing Modular Services](#chap-writing-and-reviewing).
 


### PR DESCRIPTION
Port of nixpkgs pull request 519015, "docs: split out modular services options to a separate section".

Upstream splits its chapter in two: the portable material becomes a nixpkgs manual chapter and the NixOS manual keeps a pointer chapter with the systemd-specific options. This book is one book about the subsystem rather than one chapter per integration, so the split is not ported and the text lands in the single chapter.

The chapter gains the matrix channel and tracking issue in place of the stale pull-request link, `nimi` and `finix` in the framework list, `finit` in the service-manager sentence, a "Motivation" section on what a module *as* a service buys over options *in* a module and over a plain unit file, and a portable-only service example at the top of "Portability". The nixpkgs manual build plumbing and the `bundledModularServiceNames` refactor have no counterpart here and are listed under *Not ported* in `PROVENANCE.md`.

Assisted-by: Claude:claude-fable-5-1
