### PR TITLE
modular-services: add git-pages

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -89,6 +89,7 @@ in the pinned nixpkgs.
 | `integrations/nixos/tests/packages/autopush-rs.nix` | `nixos/tests/autopush-rs.nix` | modified | Keeps the `autoconnect.settings.auth_keys` line, which the pinned nixpkgs has and the variant split has not yet reached. |
 | `integrations/nixos/tests/packages/easytier.nix` | `nixos/tests/easytier-modular.nix` | modified | `pkgs.easytier.services.default` becomes `config.modularServices.easytier.default`. Upstream registers no `easytier` variant, so this one has no counterpart there. |
 | `integrations/nixos/tests/packages/ghostunnel.nix` | `nixos/tests/ghostunnel-modular.nix` | verbatim | |
+| `integrations/nixos/tests/packages/git-pages.nix` | `nixos/tests/git-pages.nix` | modified | `pkgs.git-pages.services.default` becomes `config.modularServices.git-pages.default`, the variant path the package tests here import. |
 | `integrations/nixos/tests/packages/holo-daemon.nix` | `nixos/tests/holo-daemon-modular.nix` | verbatim | |
 | `integrations/nixos/tests/packages/snid.nix` | `nixos/tests/snid.nix` | verbatim | |
 | `integrations/nixos/tests/packages/tlshd.nix` | `nixos/tests/tlshd.nix` | verbatim | |
@@ -97,6 +98,7 @@ in the pinned nixpkgs.
 | `modular-services/autopush-rs/service-autoendpoint.nix` | `pkgs/by-name/au/autopush-rs/service-autoendpoint.nix` | modified | The systemd hardening moves to `integrations/nixos/modular/autopush-rs/autoendpoint/system.nix`, leaving the service itself naming no service manager. |
 | `modular-services/easytier/service.nix` | `pkgs/by-name/ea/easytier/service.nix` | verbatim | |
 | `modular-services/ghostunnel/service.nix` | `pkgs/by-name/gh/ghostunnel/service.nix` | modified | The systemd definitions, including the credential flags `mainExecStart` appends, move to `integrations/nixos/modular/ghostunnel/default/system.nix`. |
+| `modular-services/git-pages/service.nix` | `pkgs/by-name/gi/git-pages/service.nix` | verbatim | |
 | `modular-services/holo-daemon/service.nix` | `pkgs/by-name/ho/holo-daemon/service.nix` | verbatim | |
 | `modular-services/ktls-utils/service.nix` | `pkgs/by-name/kt/ktls-utils/service.nix` | modified | The systemd definitions move to `integrations/nixos/modular/ktls-utils/default/system.nix`. |
 | `modular-services/snid/service.nix` | `pkgs/by-name/sn/snid/service.nix` | modified | The systemd definitions move to `integrations/nixos/modular/snid/default/system.nix`. |
@@ -132,6 +134,13 @@ in the pinned nixpkgs.
   CI plumbing; neither the ownership file nor that test is vendored here.
 - `nixos/modules/system/service/README.md`. Superseded by
   [`integrations/nixos/README.md`](./integrations/nixos/README.md).
+- `pkgs/by-name/gi/git-pages/package.nix`. Its `passthru.services.default`
+  is the wiring that lives in
+  [`modular-services/default.nix`](./modular-services/default.nix) here. The
+  same file also patches the package so the server creates its storage root
+  with `os.MkdirAll`, which the service module depends on; the `git-pages`
+  entry in `modular-services/default.nix` applies that patch to the pinned
+  package until nixpkgs carries it.
 
 [nixpkgs]: https://github.com/NixOS/nixpkgs
 [Home Manager]: https://github.com/nix-community/home-manager

--- a/doc/registry.nix
+++ b/doc/registry.nix
@@ -13,6 +13,7 @@
   "autopush-rs-autoendpoint"
   "easytier"
   "ghostunnel"
+  "git-pages"
   "holo-daemon"
   "ktls-utils"
   "php"

--- a/integrations/nixos/modular/default.nix
+++ b/integrations/nixos/modular/default.nix
@@ -16,6 +16,7 @@
 {
   system = {
     ghostunnel.default = ./ghostunnel/default/system.nix;
+    git-pages.default = ./git-pages/default/system.nix;
     snid.default = ./snid/default/system.nix;
     ktls-utils.default = ./ktls-utils/default/system.nix;
     autopush-rs = {

--- a/integrations/nixos/modular/git-pages/default/default.nix
+++ b/integrations/nixos/modular/git-pages/default/default.nix
@@ -1,0 +1,5 @@
+{ modularServices, pkgs, ... }:
+{
+  _class = "service";
+  imports = [ (modularServices.git-pages pkgs) ];
+}

--- a/integrations/nixos/modular/git-pages/default/system.nix
+++ b/integrations/nixos/modular/git-pages/default/system.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+{
+  # git-pages has no system (NixOS) specific configuration; this variant
+  # exists so the service is advertised as supported on the NixOS system
+  # environment.
+  _class = "service";
+  imports = [ ./default.nix ];
+  meta.maintainers = with lib.maintainers; [
+    dtomvan
+    phanirithvij
+  ];
+}

--- a/integrations/nixos/tests/default.nix
+++ b/integrations/nixos/tests/default.nix
@@ -55,6 +55,7 @@ let
     autopush-rs = ./packages/autopush-rs.nix;
     easytier = ./packages/easytier.nix;
     ghostunnel = ./packages/ghostunnel.nix;
+    git-pages = ./packages/git-pages.nix;
     holo-daemon = ./packages/holo-daemon.nix;
     snid = ./packages/snid.nix;
     tlshd = ./packages/tlshd.nix;

--- a/integrations/nixos/tests/packages/git-pages.nix
+++ b/integrations/nixos/tests/packages/git-pages.nix
@@ -1,0 +1,65 @@
+{ pkgs, ... }:
+{
+  name = "git-pages-modular-service";
+
+  nodes.machine = { config, pkgs, ... }: {
+    environment.systemPackages = [ pkgs.curl ];
+
+    system.services.git-pages = {
+      imports = [ config.modularServices.git-pages.default ];
+      git-pages = {
+        settings.server = {
+          pages = "tcp/:3000";
+          caddy = "tcp/:3001";
+          metrics = "tcp/:3002";
+        };
+      };
+      systemd.service.environment.PAGES_INSECURE = "1";
+    };
+
+    services.caddy = {
+      enable = true;
+      configFile = pkgs.writeText "Caddyfile" ''
+        {
+            admin off
+            persist_config off
+            auto_https disable_redirects
+            on_demand_tls {
+                permission http http://localhost:3001
+            }
+        }
+        https://, http:// {
+          tls {
+              on_demand
+          }
+          reverse_proxy http://localhost:3000
+        }
+      '';
+    };
+
+    networking.firewall.allowedTCPPorts = [ 80 ];
+  };
+
+  testScript =
+    let
+      testSite = pkgs.runCommand "git-pages-testsite.tar" { } ''
+        echo It works! > index.html
+        tar cvf $out index.html
+      '';
+    in
+    ''
+      start_all()
+
+      machine.wait_for_unit("caddy.service")
+      machine.wait_for_open_port(80)
+      machine.wait_for_unit("git-pages.service")
+      machine.wait_for_open_port(3001)
+      machine.wait_for_open_port(3002)
+      machine.fail("curl -f http://localhost/.git-pages/health")
+      machine.succeed("curl -f http://localhost/ -X PUT --data-binary @${testSite} --header 'Content-Type: application/x-tar'")
+      machine.wait_until_succeeds("test -f /var/lib/git-pages/data/site/localhost/.index")
+      machine.succeed("curl -f http://localhost/.git-pages/health")
+      machine.succeed("curl -f http://localhost/ | grep -F 'It works!'")
+      machine.succeed("curl -f http://localhost:3002/metrics")
+    '';
+}

--- a/modular-services/default.nix
+++ b/modular-services/default.nix
@@ -45,6 +45,28 @@ in
     ghostunnel.package = lib.mkDefault pkgs.ghostunnel;
   };
 
+  git-pages = pkgs: {
+    imports = [
+      (importApply ./git-pages/service.nix {
+        inherit (pkgs) formats coreutils;
+      })
+    ];
+    # Upstream patches the package so the server creates its storage root with
+    # `os.MkdirAll`. The service relies on that instead of an `ExecStartPre`.
+    # Drop the override when the pinned nixpkgs carries the patch.
+    git-pages.package = lib.mkDefault (
+      pkgs.git-pages.overrideAttrs (previousAttrs: {
+        patches = (previousAttrs.patches or [ ]) ++ [
+          (pkgs.fetchpatch {
+            name = "mkdirall-parent-dir-create.patch";
+            url = "https://codeberg.org/git-pages/git-pages/commit/507e57edbcfc0ec933a877bf26b1756ca0a61870.patch";
+            hash = "sha256-1CjU4yGmDOmYsxo3U44Cg2xLJkrmUOX5ZXTycdLs6OE=";
+          })
+        ];
+      })
+    );
+  };
+
   holo-daemon = pkgs: {
     imports = [ (importApply ./holo-daemon/service.nix { inherit pkgs; }) ];
     holo-daemon.package = lib.mkDefault pkgs.holo-daemon;

--- a/modular-services/git-pages/service.nix
+++ b/modular-services/git-pages/service.nix
@@ -1,0 +1,116 @@
+# Non-module dependencies (`importApply`)
+{ formats, coreutils }:
+
+{
+  config,
+  lib,
+  options,
+  name,
+  ...
+}:
+let
+  cfg = config.git-pages;
+  settingsFormat = formats.toml { };
+  configFile = "git-pages.toml";
+  configOutPath = config.configData.${configFile}.path;
+in
+{
+  _class = "service";
+
+  meta.maintainers = with lib.maintainers; [
+    dtomvan
+    phanirithvij
+  ];
+
+  options.git-pages = {
+    package = lib.mkOption {
+      description = "Package to use for git-pages";
+      defaultText = "The git-pages package that provided this module.";
+      type = lib.types.package;
+    };
+
+    secretFile = lib.mkOption {
+      description = ''
+        File that contains secrets for the git-pages config.
+        If values in this file are set, any options specified take priority over the options set in
+        {option}`git-pages.settings`.
+
+        ::: {.note}
+        See the [git-pages documentation](https://git-pages.org/running-a-server/#configuration) on
+        secrets and environment variables.
+        :::
+      '';
+      default = null;
+      type = lib.types.nullOr lib.types.str;
+    };
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      description = ''
+        Settings to set in config.toml.
+
+        ::: {.note}
+        See the [git-pages documentation](https://git-pages.org/running-a-server/#configuration) on configuring the server.
+        :::
+      '';
+      default = { };
+    };
+  };
+
+  config = {
+    git-pages.settings.storage.fs.root = lib.mkDefault "/var/lib/${name}/data";
+
+    process.argv = [
+      (lib.getExe cfg.package)
+      "-config"
+      configOutPath
+    ];
+
+    configData."${configFile}".source = settingsFormat.generate configFile cfg.settings;
+  }
+  // lib.optionalAttrs (options ? systemd) {
+    systemd.service = {
+      description = "Forge-agnostic static site server";
+      documentation = [ "https://git-pages.org/running-a-server/" ];
+
+      after = [ "network.target" ];
+      wants = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ config.configData."${configFile}".source ];
+
+      serviceConfig = {
+        Restart = "always";
+
+        StateDirectory = name;
+        WorkingDirectory = "%S/${name}";
+        BindReadOnlyPaths = [ configOutPath ];
+
+        LoadCredential = lib.optional (cfg.secretFile != null) "secrets.toml:${cfg.secretFile}";
+
+        User = name;
+        DynamicUser = true;
+
+        # systemd service hardening
+        ProtectHome = true;
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        ProtectKernelLogs = true;
+        ProtectKernelTunables = true;
+        ProtectHostname = true;
+        ProtectKernelModules = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        SystemCallArchitectures = "native";
+        SystemCallErrorNumber = "EPERM";
+        SystemCallFilter = "@system-service";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Port of nixpkgs pull request 554366, "git-pages.services.default: init", tracking its head as of 2026-09-04.

Adds `modular-services/git-pages/service.nix`, unchanged from upstream, with the `{ formats, coreutils }` non-module dependencies wired in `modular-services/default.nix`, a `doc/registry.nix` entry, a NixOS variant under `integrations/nixos/modular/git-pages/default/` that only imports the pure base so the registry advertises the service on the system environment, and the VM test as `integrations/nixos/tests/packages/git-pages.nix` (`checks.nixos-pkg-git-pages`). The test imports `config.modularServices.git-pages.default`, the way the other package tests here reach their service.

Upstream also patches the `git-pages` package so the server creates its storage root with `os.MkdirAll`, and the service module relies on that instead of an `ExecStartPre`. The pinned nixpkgs does not carry the patch yet, so the `git-pages` entry in `modular-services/default.nix` applies it to the default package. `PROVENANCE.md` records this under *Not ported* against `pkgs/by-name/gi/git-pages/package.nix`.

Assisted-by: Claude:claude-fable-5-1
