### PR TITLE
services: apply `configData` changes on activation

### DIFF
--- a/integrations/nixos/README.md
+++ b/integrations/nixos/README.md
@@ -56,6 +56,26 @@ in
 }
 ```
 
+## Applying `configData` changes
+
+A `configData` entry becomes an `environment.etc` file, so a change to one is
+part of the system closure and is on disk the moment a configuration is
+activated. Whether the running service is told about it is
+`applyConfigDataChanges`, which the portable layer declares next to `configData`
+itself: "this service picks up configuration changes on its own" is a property
+of the program, not of the service manager. It is a `bool` rather than a
+reload-or-restart enum, so it says only *whether* changes should be applied and
+leaves *how* to the service manager. A single noisy file opts out on its own
+through `configData.<name>.applyChanges`, which defaults to `null` and so
+inherits the service-level setting.
+
+Here, *how* is a trigger on the service's primary unit: `reloadTriggers` when
+the unit declares an `ExecReload`, and `restartTriggers` when it does not.
+`switch-to-configuration-ng` does not fall back from reload to restart --
+`X-Reload-Triggers` on a unit without `ExecReload=` makes activation exit with
+code 4 -- so the choice is made when the unit is generated. Sub-services get
+their triggers from their own `configData`, not from the parent's.
+
 ## Known residue
 
 Two things survive the disable. Both are documented rather than fixed, because

--- a/integrations/nixos/systemd/system.nix
+++ b/integrations/nixos/systemd/system.nix
@@ -47,15 +47,60 @@ let
     in
     serviceConfigData // subServiceConfigData;
 
+  configDataSources =
+    service:
+    let
+      applyDefault = service.applyConfigDataChanges or true;
+    in
+    lib.mapAttrsToList (_: cfg: cfg.source) (
+      lib.filterAttrs (
+        _: cfg: cfg.enable && (if cfg.applyChanges == null then applyDefault else cfg.applyChanges)
+      ) (service.configData or { })
+    );
+
+  # Whether a unit declares a command to reload with. `serviceConfig.ExecReload` is always
+  # defined by ./service.nix, as `systemd.mainExecReload`, which is the empty string when the
+  # service has no `process.reloadCommand`. An empty entry resets systemd's command list
+  # rather than adding to it, so it does not make the unit reloadable.
+  hasExecReload =
+    unitConfig:
+    let
+      execReload = unitConfig.serviceConfig.ExecReload or null;
+    in
+    if execReload == null then
+      false
+    else if lib.isList execReload then
+      lib.any (cmd: cmd != "") execReload
+    else
+      execReload != "";
+
   makeUnits =
     unitType: prefix: service:
-    concatMapAttrs (unitName: unitModule: {
-      "${dash prefix unitName}" =
-        { ... }:
-        {
-          imports = [ unitModule ];
-        };
-    }) service.systemd.${unitType}
+    let
+      sources = configDataSources service;
+    in
+    concatMapAttrs (
+      unitName: unitModule:
+      let
+        extra = lib.optional (unitType == "services" && unitName == "" && sources != [ ]) (
+          { config, ... }:
+          {
+            # switch-to-configuration-ng does not fall back from reload to restart:
+            # X-Reload-Triggers on a unit without ExecReload= causes activation to
+            # exit with code 4. Use reloadTriggers only when ExecReload is declared.
+            reloadTriggers = lib.mkIf (hasExecReload config) sources;
+            restartTriggers = lib.mkIf (!hasExecReload config) sources;
+          }
+        );
+      in
+      {
+        "${dash prefix unitName}" =
+          { ... }:
+          {
+            imports = [ unitModule ] ++ extra;
+          };
+      }
+    ) service.systemd.${unitType}
     // concatMapAttrs (
       subServiceName: subService: makeUnits unitType (dash prefix subServiceName) subService
     ) service.services;

--- a/integrations/nixos/tests/etc/test.nix
+++ b/integrations/nixos/tests/etc/test.nix
@@ -23,7 +23,10 @@
         system.services.webserver = {
           # The python web server is simple enough that it doesn't need a reload signal.
           # Other services may need to receive a signal in order to re-read what's in `configData`.
+          # It reads the files on every request, so the service manager must leave it alone when
+          # they change.
           imports = [ python-http-server ];
+          applyConfigDataChanges = false;
           python-http-server = {
             port = 8080;
           };
@@ -49,6 +52,7 @@
           # Add a sub-service
           services.api = {
             imports = [ python-http-server ];
+            applyConfigDataChanges = false;
             python-http-server = {
               port = 8081;
             };

--- a/integrations/nixos/tests/units.nix
+++ b/integrations/nixos/tests/units.nix
@@ -91,6 +91,52 @@ let
             config.systemd.lib.escapeSystemdExecArgs config.process.argv + " --systemd-unit %n";
         };
 
+      # Test that configData sources are wired into restartTriggers on
+      # the primary unit (no ExecReload), including for sub-services,
+      # while disabled entries are excluded.
+      system.services.cfgtest = {
+        process.argv = [ hello' ];
+        configData."app.conf".text = "hello = world\n";
+        configData."disabled.conf" = {
+          text = "should not appear\n";
+          enable = false;
+        };
+        configData."noapply.conf" = {
+          text = "not applied on activation\n";
+          applyChanges = false;
+        };
+        services.sub = {
+          process.argv = [ hello' ];
+          configData."sub.conf".text = "sub = yes\n";
+        };
+      };
+
+      # Test that configData sources are wired into reloadTriggers when
+      # ExecReload is declared.
+      system.services.cfgtest-reload = {
+        process.argv = [ hello' ];
+        process.reloadCommand = "${hello}/bin/hello";
+        configData."reload.conf".text = "reload = me\n";
+      };
+
+      # Test that applyConfigDataChanges = false opts the whole service out.
+      system.services.cfgtest-noapply = {
+        process.argv = [ hello' ];
+        applyConfigDataChanges = false;
+        configData."skip.conf".text = "skip = yes\n";
+      };
+
+      # Test that a per-entry applyChanges overrides the service-level setting.
+      system.services.cfgtest-noapply-override = {
+        process.argv = [ hello' ];
+        applyConfigDataChanges = false;
+        configData."skip.conf".text = "skip = yes\n";
+        configData."forced.conf" = {
+          text = "forced = yes\n";
+          applyChanges = true;
+        };
+      };
+
       # irrelevant stuff
       system.stateVersion = "25.05";
       fileSystems."/" = {
@@ -140,6 +186,47 @@ runCommand "test-modular-service-systemd-units"
       [[ ! -e ${toplevel}/etc/systemd/system/foo.socket ]]
       [[ ! -e ${toplevel}/etc/systemd/system/bar.socket ]]
       [[ ! -e ${toplevel}/etc/systemd/system/bar-db.socket ]]
+
+      # cfgtest has no ExecReload, so configData sources go into restartTriggers
+      # (X-Restart-Triggers), not reloadTriggers.
+      grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest.service >/dev/null
+      cfgtest_trigger=$(grep -oP '^X-Restart-Triggers=\K\S+' ${toplevel}/etc/systemd/system/cfgtest.service)
+      grep -F "service-configdata-app.conf" "$cfgtest_trigger" >/dev/null
+      ! grep -F "service-configdata-disabled.conf" "$cfgtest_trigger" >/dev/null
+      # Entries with applyChanges = false are excluded.
+      ! grep -F "service-configdata-noapply.conf" "$cfgtest_trigger" >/dev/null
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/cfgtest.service >/dev/null
+
+      # Sub-service primary unit gets its own configData via restartTriggers, not the parent's.
+      grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-sub.service >/dev/null
+      cfgtest_sub_trigger=$(grep -oP '^X-Restart-Triggers=\K\S+' ${toplevel}/etc/systemd/system/cfgtest-sub.service)
+      grep -F "service-configdata-sub.conf" "$cfgtest_sub_trigger" >/dev/null
+      ! grep -F "service-configdata-app.conf" "$cfgtest_sub_trigger" >/dev/null
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-sub.service >/dev/null
+
+      # cfgtest-reload declares ExecReload, so configData sources go into reloadTriggers.
+      grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-reload.service >/dev/null
+      cfgtest_reload_trigger=$(grep -oP '^X-Reload-Triggers=\K\S+' ${toplevel}/etc/systemd/system/cfgtest-reload.service)
+      grep -F "service-configdata-reload.conf" "$cfgtest_reload_trigger" >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-reload.service >/dev/null
+
+      # applyConfigDataChanges = false opts the service out entirely.
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-noapply.service >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-noapply.service >/dev/null
+
+      # A per-entry applyChanges = true overrides applyConfigDataChanges = false.
+      grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/cfgtest-noapply-override.service >/dev/null
+      cfgtest_override_trigger=$(grep -oP '^X-Restart-Triggers=\K\S+' ${toplevel}/etc/systemd/system/cfgtest-noapply-override.service)
+      grep -F "service-configdata-forced.conf" "$cfgtest_override_trigger" >/dev/null
+      ! grep -F "service-configdata-skip.conf" "$cfgtest_override_trigger" >/dev/null
+
+      # Services without configData should have neither X-Reload-Triggers nor X-Restart-Triggers.
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/bar.service >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/bar.service >/dev/null
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/bar-db.service >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/bar-db.service >/dev/null
+      ! grep -E '^X-Reload-Triggers=' ${toplevel}/etc/systemd/system/foo.service >/dev/null
+      ! grep -E '^X-Restart-Triggers=' ${toplevel}/etc/systemd/system/foo.service >/dev/null
     )
     echo 🐬👍
     touch $out

--- a/lib/services/config-data-item.nix
+++ b/lib/services/config-data-item.nix
@@ -51,6 +51,16 @@ in
       type = types.path;
       description = "Path of the source file.";
     };
+
+    applyChanges = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether a change in this file should be applied to the running service during activation.
+
+        `null` means to use the service's {option}`applyConfigDataChanges` setting.
+      '';
+    };
   };
 
   config = {

--- a/lib/services/config-data.nix
+++ b/lib/services/config-data.nix
@@ -43,5 +43,17 @@ in
 
       type = types.lazyAttrsOf (types.submodule (importApply ./config-data-item.nix pkgs));
     };
+
+    applyConfigDataChanges = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether the service manager should apply changes to this service's {option}`configData` when the configuration is activated, by reloading the service if it can be reloaded, or restarting it otherwise.
+
+        Set this to `false` for services that watch their own configuration files, or where interrupting the service is unacceptable.
+
+        Individual entries may override this with {option}`configData.<name>.applyChanges`.
+      '';
+    };
   };
 }


### PR DESCRIPTION
Port of nixpkgs pull request 518717, "nixos/modular-services: reload/restart on `configData` change".

The portable layer gains `applyConfigDataChanges` next to `configData`, and `configData.<name>.applyChanges` per entry. The systemd integration turns those into a trigger on the service's primary unit: `reloadTriggers` when the unit declares an `ExecReload`, `restartTriggers` otherwise. Every file matches the upstream change; only the paths differ. Upstream's design notes for `nixos/modules/system/service/README.md` land in `integrations/nixos/README.md`, which supersedes that file here.

Assisted-by: Claude:claude-fable-5-1
