### PR TITLE
doc: describe consumption through the NixOS variant registry

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -51,12 +51,12 @@ with the reason; those are the only places where a divergence exists at all.
 
 No `SPDX-License-Identifier` line either. Those earn their keep when files in one
 tree carry different licences; here every file is MIT under the same notice, so a
-header per file would restate `LICENSE` 53 times and still not say which upstream
-the file came from -- which is the question this table answers.
+header per file would restate `LICENSE` once per file and still not say which
+upstream the file came from -- which is the question this table answers.
 
 No per-row revision either. [`flake.lock`](./flake.lock) records the pin, and a
-second copy per row would only be another thing to keep in step, touching all 39
-rows on every re-vendor. Note that the pin is the `nixos-unstable` channel, which
+second copy per row would only be another thing to keep in step, touching every
+row on every re-vendor. Note that the pin is the `nixos-unstable` channel, which
 advances only once Hydra has built it and so trails the nixpkgs default branch by
 a few days: a file vendored from the branch can be *newer* than its counterpart
 in the pinned nixpkgs.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ whatever the system, and a flake publishes them unkeyed.
 | `lib/services/` | The portable layer. No nixpkgs paths, no `pkgs` module argument. |
 | `compliance/` | The integration-agnostic compliance suite each integration instantiates. |
 | `integrations/` | One directory per integration. See [`integrations/README.md`](./integrations/README.md). |
-| `modular-services/` | The services themselves: `_class = "service"`, integration-agnostic, one directory per providing package. |
+| `modular-services/` | The services themselves: `_class = "service"`, integration-agnostic, one directory per providing package. What each needs from systemd is a variant under `integrations/nixos/modular/`. |
 | `doc/` | The manual: its hand-written chapters, and the lists its generated ones render -- the services whose options it documents, and what each output is for. One book about the subsystem, not one per integration; each integration renders the service list its own way. |
 | `overlays/`, `ci/` | Overlays, and the test/matrix wiring. |
 | `default.nix`, `flake.nix` | Every output, and the flake wrapper that keys the per-system ones by system. |

--- a/default.nix
+++ b/default.nix
@@ -13,13 +13,13 @@
 #
 # ```nix
 # # in a NixOS configuration, with `src` however you fetched this repository
-# { pkgs, ... }:
+# { config, pkgs, ... }:
 # let
 #   modular-services = import src { inherit (pkgs) lib; };
 # in
 # {
 #   imports = [ modular-services.nixosModules.default ];
-#   system.services.tlshd.imports = [ (modular-services.modularServices.ktls-utils pkgs) ];
+#   system.services.tlshd.imports = [ config.modularServices.ktls-utils.default ];
 # }
 # ```
 {
@@ -77,8 +77,10 @@ let
     };
 
     /**
-      The canonical way to consume a service: `modularServices.<pkg> pkgs` yields a
-      module to import into `system.services.<name>`.
+      The services on their own: `modularServices.<pkg> pkgs` yields the module
+      that names no service manager, for an integration to build on. A NixOS
+      configuration imports `config.modularServices.<pkg>.<svc>` instead, the
+      variant `integrations/nixos/modular/` adds the systemd definitions to.
     */
     inherit modularServices;
 

--- a/doc/design/philosophy.md
+++ b/doc/design/philosophy.md
@@ -245,17 +245,21 @@ See [nixpkgs#469450][mainexecstart].
 
 ## Declare a difference rather than hiding it
 
-Note that wee are considering alternatives for this `options ? ...` approach, such as letting the service manager integration extend the module set ([nixpkgs#540863]).
-The following two paragraphs describe the status quo.
+Portability here works by keeping the manager-specific definitions out of the
+service module. A module under `modular-services/` says what a service is, and
+what only holds under one service manager lives in a variant owned by the
+integration that understands it: `integrations/nixos/modular/<pkg>/<svc>/system.nix`
+for NixOS on systemd, registered as `config.modularServices.<pkg>.<svc>`
+([nixpkgs#540863]). The service is then portable by construction.
 
-Portability here works by feature detection on the definition side.
-A service wraps its systemd definitions in `lib.optionalAttrs (options ? systemd)`,
-and they are ignored where that option does not exist.
-The `php` service keeps a dormant `options ? finit` branch for the same reason.
+The older escape hatch remains available for a definition that varies inline:
+feature detection on the definition side, wrapping systemd definitions in
+`lib.optionalAttrs (options ? systemd)` so that they fall away where that option
+does not exist.
 
-This is deliberately not an abstraction that papers over the managers. It is a
-way for a definition to say what it knows about, and for the parts it does not
-know about to fall away.
+Neither is an abstraction that papers over the managers. Both are a way for a
+definition to say what it knows about, and for the parts it does not know about
+to fall away.
 
 The principle of declaring differences also decides smaller questions.
 Readiness is modelled as a negotiation in which the service says which notification dialect it can emit

--- a/doc/flake-attributes.nix
+++ b/doc/flake-attributes.nix
@@ -73,6 +73,16 @@ let
     lib.attrNames self.modularServices
   );
 
+  # The NixOS variants, read from the registry the `modularServices` option
+  # defaults to.
+  variantModules = lib.concatStringsSep "\n" (
+    lib.concatLists (
+      lib.mapAttrsToList (
+        pkg: svcs: map (svc: "- `config.modularServices.${pkg}.${svc}`") (lib.attrNames svcs)
+      ) (import ../integrations/nixos/modular).system
+    )
+  );
+
   checkRows = lib.concatMapStringsSep "\n" (
     n:
     let
@@ -113,6 +123,10 @@ pkgs.writeText "flake-attributes.md" ''
   ${oneLine generated.modularServices}
 
   ${serviceModules}
+
+  The NixOS variant of each, which a configuration imports:
+
+  ${variantModules}
 
   ## ${groups.checks.title} {#${groups.checks.anchor}}
 

--- a/doc/outputs.nix
+++ b/doc/outputs.nix
@@ -17,8 +17,9 @@
     "lib.mkComplianceSuite" = "The integration-agnostic compliance suite, for a package set.";
 
     "nixosModules.default" =
-      "This repository's implementation, plus the disable of the nixpkgs copy. The one to import.";
-    "nixosModules.systemServices" = "Just the systemd implementation, without the disable.";
+      "This repository's implementation and the `modularServices` variant registry, plus the disable of the nixpkgs copy. The one to import.";
+    "nixosModules.systemServices" =
+      "Just the systemd implementation and the variant registry, without the disable.";
     "nixosModules.disableUpstream" = "Just the disable, without the implementation.";
     "nixosModules.documentation" =
       "Replacement for the option-documentation registry that the disable removes.";

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -33,10 +33,12 @@ answers, one level deep.
 
 Flat bounds `integrations/` itself, not what an integration contains. The
 implementation sits one level down, in a directory named for the service manager
-it targets: `integrations/nixos/systemd/`. A framework that grows a second
-manager -- NixOS on finit, say -- gets a sibling there rather than a second
-integration, since it shares both answers, and `integrations/nixos/default.nix`
-is where the choice between them is made.
+it targets: `integrations/nixos/systemd/`. Beside it, `integrations/nixos/modular/`
+holds the *variants*: for each service, the definitions that only that manager
+understands, registered as `config.modularServices.<pkg>.<svc>`. A framework
+that grows a second manager -- NixOS on finit, say -- gets a sibling of both
+there rather than a second integration, since it shares both answers, and
+`integrations/nixos/default.nix` is where the choice between them is made.
 
 The rule is about those two answers rather than about an axis, because the axes
 are not knowable up front. Three are visible already and they do not nest: the
@@ -47,10 +49,10 @@ Whether a permutation is then a second integration, a second implementation
 inside this one, or a variant key is worth deciding against something that runs.
 Four small files per integration is what keeps that decision cheap to revisit.
 
-Two in-progress upstream changes show the rule applied, and it lands on opposite
-sides of them.
+Two upstream changes show the rule applied, and it lands on opposite sides of
+them.
 
-The first declares `users.users.<name>.services` as a NixOS module siphoning into
+The first, in progress, declares `users.users.<name>.services` as a NixOS module siphoning into
 `systemd.user.services`, reusing the same `service.nix` and reading
 `config.systemd.package` from the same evaluation as `system.services`. An
 `integrations/nixos-user/` would restate all four contract files to describe one
@@ -58,22 +60,23 @@ evaluation, and would double the NixOS test runs to prove it twice. It is a
 second option surface inside `integrations/nixos/`, nested under `systemd/` as
 `system/` and `user/` the way upstream nests it.
 
-The second splits each service module in two: a pure half, and a variant holding
-what only holds in one place -- `DynamicUser`, `AmbientCapabilities`,
-`wantedBy = [ "multi-user.target" ]` -- enumerated in a registry keyed
-`<variant>.<pkg>.<service>`, with `system` today and `user` expected beside it.
-Upstream calls that first key an environment; by the rule above it is not an
+The second, landed here, splits each service module in two: a pure half in
+`modular-services/`, and a variant holding what only holds in one place --
+`DynamicUser`, `AmbientCapabilities`, `wantedBy = [ "multi-user.target" ]` --
+enumerated in a registry keyed `<environment>.<pkg>.<service>`, with `system`
+today and `user` expected beside it. The environment key is not an
 integration, because it selects a service module rather than an evaluation, and
 it selects along the privilege level of a systemd unit, which cuts *across*
 frameworks. Home Manager emits systemd user units too, so a `user` variant is one
-both it and NixOS want. An `integrations/nixos-user/` would bury it in one
-framework's directory, for the other to reach into.
+both it and NixOS want.
 
-Variants therefore belong beside the services they vary, in
-`modular-services/`, and an integration owns the *registry*: which variant key
-it consumes, and which services it claims to support there. Upstream keeps its
-registry under `nixos/modules/`, having one integration to serve; that placement
-is the one part of its shape that does not carry over.
+The variants and their registry live in the integration whose service manager
+they speak for, `integrations/nixos/modular/`, mirroring upstream's
+`nixos/modules/system/service/modular/`; see
+[`nixos/README.md`](./nixos/README.md). What that placement leaves open is how a
+second integration on the same service manager shares a variant rather than
+reaching into `integrations/nixos/` for it. Worth deciding against something
+that runs, when Home Manager arrives.
 
 Home Manager decides the other way on the same reasoning. It also targets systemd
 user units, and it is still its own integration, because a Home Manager
@@ -90,11 +93,11 @@ configuration is evaluated and tested through an entirely different entry point.
   `callReload`, and may add its own manager-specific assertions on top;
   `integrations/nixos/tests/compliance.nix` shows both halves.
 - **The services** (`modular-services/`) are shared: every one declares
-  `_class = "service"` and none imports anything from `lib/services`. A service
-  that needs settings holding at only one privilege level gets a variant beside
-  the pure module, not a copy inside an integration; see "What makes an
-  integration" above. An integration that cannot run a given service simply does
-  not test it.
+  `_class = "service"`, none imports anything from `lib/services`, and none
+  names a service manager. What a service needs from one manager is a variant in
+  the integration that understands it, `integrations/nixos/modular/<pkg>/<svc>/`
+  for NixOS, not a copy of the service; see "What makes an integration" above.
+  An integration that cannot run a given service simply does not test it.
 
 ## Where to start
 
@@ -106,7 +109,7 @@ sketch. Then mirror `integrations/nixos/` for the other three files.
 Home Manager is the intended next integration; it slots in as
 `integrations/home-manager/` under the same four-file contract. [finix], which
 runs finit as pid 1, is the other obvious candidate: it already carries its own
-integration, and `modular-services/php/service.nix` keeps upstream's dormant
-`lib.optionalAttrs (options ? finit)` branch for exactly that manager.
+integration, and the `finit` half of each service would sit beside the systemd
+one as a second variant.
 
 [finix]: https://github.com/finix-community/finix

--- a/integrations/nixos/documentation.nix
+++ b/integrations/nixos/documentation.nix
@@ -27,7 +27,7 @@ let
       type = lib.types.submoduleWith {
         modules = [ serviceModule ];
       };
-      description = "This is a [modular service](https://nixos.org/manual/nixos/unstable/#modular-services), which can be imported into a NixOS configuration using the [`system.services`](https://search.nixos.org/options?channel=unstable&show=system.services&query=modular+service) option.";
+      description = "This is a [modular service](https://nixos.org/manual/nixos/unstable/#modular-services), which can be imported into a NixOS configuration using the [`system.services`](https://search.nixos.org/options?channel=unstable&show=system.services&query=modular+service) option. `config.modularServices.<pkg>.<svc>` is this service together with the systemd definitions the NixOS integration adds; `modularServices.<name> pkgs` is the service on its own.";
     };
 
   modularServicesModule = {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -3,7 +3,9 @@
 # override anything.
 #
 # `modularServices.<name> pkgs` is the same value; this overlay only saves
-# threading the flake through to the place that needs a service module.
+# threading the flake through to the place that needs a service module. It is
+# the service on its own, without systemd definitions: a NixOS configuration
+# imports `config.modularServices.<pkg>.<svc>` instead.
 { modularServices }:
 
 final: _prev: {

--- a/overlays/passthru-services.nix
+++ b/overlays/passthru-services.nix
@@ -2,7 +2,9 @@
 # service modules instead of the ones vendored in nixpkgs.
 #
 # Not part of `overlays.default`, and not used by any test in this repo. The
-# canonical API is `modularServices.<pkg> pkgs`, for three reasons:
+# canonical API is `modularServices.<pkg> pkgs` for the service on its own, and
+# `config.modularServices.<pkg>.<svc>` for the NixOS variant of it, for three
+# reasons:
 #
 #   1. `passthru.services` is upstream's attribute. Silently swapping it makes
 #      it impossible to A/B a service against the nixpkgs copy, which is much
@@ -41,8 +43,9 @@ in
 # `passthru.overrideAttrs`, and `php.buildEnv` / `php.withExtensions`
 # regenerate `passthru.services` from `mkBuildEnv`. An overlay entry here would
 # therefore be silently discarded by exactly the wrappers that real
-# configurations use. Consume `modularServices.php pkgs` instead; that is the
-# decisive reason `modularServices` is the canonical API rather than an overlay.
+# configurations use. Consume `modularServices.php pkgs`, or on NixOS
+# `config.modularServices.php.default`, instead; that is the decisive reason
+# `modularServices` is the canonical API rather than an overlay.
 lib.foldl' lib.mergeAttrs { } [
   (withServices "easytier" { default = modularServices.easytier final; })
   (withServices "ghostunnel" { default = modularServices.ghostunnel final; })


### PR DESCRIPTION
Follow-up to the port of nixpkgs pull request 540863 (merged as pull request 17): `config.modularServices.<pkg>.<svc>` is now how a NixOS configuration consumes a service, and `modularServices.<pkg> pkgs` is the service on its own. This updates the prose that still described the older shape.

- The consumption example and `modularServices` docstring in `default.nix`, the overlay headers, and the description the rendered option documentation gives each service now name both paths.
- `doc/design/philosophy.md` presented `options ? systemd` feature detection as the status quo and the split as an alternative under consideration, and named a `finit` branch the `php` service no longer has. It now describes the variant as the primary mechanism and feature detection as the inline escape hatch.
- `integrations/README.md` argued that variants belong beside the services in `modular-services/` and marked the split as in progress. It now describes where the variants and their registry live (`integrations/nixos/modular/`, mirroring upstream), and leaves open how a second integration on the same service manager would share one. Worth a look, since the merged placement is the opposite of what that section argued for.
- The layout table in `README.md` and the `nixosModules` rows of the outputs chapter mention the registry.
- The flake-attributes chapter lists the variants, read from the registry, beside the service modules.
- The two counts in `PROVENANCE.md` prose had drifted and are reworded so they cannot drift again.

`ci/non-flake.nix` still consumes `(modularServices.ktls-utils pkgs)` directly, so the non-flake consumer check does not exercise the documented `config.modularServices` path; left as is here, since that is a test change rather than a documentation one.

Assisted-by: Claude:claude-fable-5-1